### PR TITLE
The `scheme` default is not really good, and the same goes for the `begin

### DIFF
--- a/irc-process-line.rkt
+++ b/irc-process-line.rkt
@@ -435,7 +435,7 @@
 ;; ----------------------------------------------------------------------------
 ;; Evaluation related stuffs
 
-(define *default-sandbox-language* '(begin (require scheme)))
+(define *default-sandbox-language* 'racket)
 
 (define (call/whine f . args)
   (define (on-error e)


### PR DESCRIPTION
The `scheme` default is not really good, and the same goes for the `begin' thing (which made it be more like a repl and not like writing code in a module.
