### PR TITLE
Omit compilation of files that are not meant to be compiled.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,3 @@
+#lang setup/infotab
+
+(define compile-omit-paths '("incubot-tests.rkt" "sighting-server.rkt"))


### PR DESCRIPTION
Now, when installing rudybot as a collect, raco setup doesn't try to
compile these files.
