### PR TITLE
Use `print` instead of `write` for REPL results

### DIFF
--- a/irc-process-line.rkt
+++ b/irc-process-line.rkt
@@ -506,11 +506,11 @@
                     ;; prevent flooding
                     [(>= displayed *max-values-to-display*)
                      (reply
-                      "; ~a values is enough for anybody; here's the rest in a list: ~s"
+                      "; ~a values is enough for anybody; here's the rest in a list: ~v"
                       (number->english *max-values-to-display*)
                       (filter (lambda (x) (not (void? x))) values))
                      #t]
-                    [else (reply "; Value~a: ~s"
+                    [else (reply "; Value~a: ~v"
                                  (if (positive? displayed)
                                    (format "#~a" (add1 displayed))
                                    "")


### PR DESCRIPTION
As the commit says, this change uses `print` instead of `write` for showing results from Rudybot's sandboxes. This makes it show results more like the REPL does, which could be good for consistency.
